### PR TITLE
switch server URL

### DIFF
--- a/crawlingathome.py
+++ b/crawlingathome.py
@@ -307,7 +307,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument('--name', '-n', type=str, default="ARKseal", help='Your name')
-    parser.add_argument('--url', '-u', type=str, default="http://crawlingathome.duckdns.org/", help='The Crawling Server')
+    parser.add_argument('--url', '-u', type=str, default="https://api.gagepiracy.com:4483/", help='The Crawling Server')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
I also mentioned this on Wikidepia's repo, but thought I might as well submit a PR on the forks too.

As the servers just switched, we are trying to move away from DuckDNS's DDNS service because of the fact it may have stability issues as it is a free service. @DefinatelyNotSam on discord has connected us up with a much more powerful server on their hardware, as well as a much more reliable DNS.